### PR TITLE
Avoid histogram files and constraint files entirely

### DIFF
--- a/deepab/build_fv/build_cen_fa.py
+++ b/deepab/build_fv/build_cen_fa.py
@@ -87,12 +87,10 @@ def get_cst_file(model: torch.nn.Module,
         prob_to_energy=logit_to_energy)
 
     # os.system("cat {} >> {}".format(all_cst_file, hb_cst_file))
+    hb_cst_file.extend(all_cst_file)
 
-    # two in-memory constraint sets
-    return {
-        'all_cst_file': all_cst_file,
-        'hb_cst_file': hb_cst_file
-    }
+    # one combined in-memory constraint set
+    return hb_cst_file
 
 
 def get_centroid_min_mover(
@@ -176,7 +174,7 @@ def get_fa_min_mover(
 
 def refine_fv(in_pdb_file: str,
               out_pdb_file: str,
-              cst_files,
+              cst_file,
               verbose: bool = False) -> float:
     """
     Run constrained minimization protocol on initial pdb file and return final score
@@ -203,7 +201,7 @@ def refine_fv(in_pdb_file: str,
     # from io import StringIO
     csts = pyrosetta.rosetta.core.scoring.constraints.ConstraintIO.read_constraints(
         # StringIO('\n'.join(cst_files['hb_cst_file'])),
-        pyrosetta.rosetta.std.stringstream('\n'.join(cst_files['all_cst_file'])),
+        pyrosetta.rosetta.std.stringstream('\n'.join(cst_file)),
         pyrosetta.rosetta.core.scoring.constraints.ConstraintSet(),
         pose)
     csm = get_constraint_set_mover(csts)

--- a/deepab/build_fv/utils.py
+++ b/deepab/build_fv/utils.py
@@ -13,15 +13,19 @@ def migrate_seq_numbering(source_pose: pyrosetta.Pose,
 
 
 def get_constraint_set_mover(
-    constraint_file: str = None,
-    **kwargs
+    csts: pyrosetta.rosetta.core.scoring.constraints.ConstraintSet#,
+    #**kwargs
 ) -> pyrosetta.rosetta.protocols.constraint_movers.ConstraintSetMover:
-    if constraint_file == None:
-        constraint_file = get_filtered_constraint_file(**kwargs)
+    
+    if csts == None:
+        print("We're now operating under logic where this shouldn't be possible")
+        quit()
+    #    constraint_file = get_filtered_constraint_file(**kwargs)
 
     csm = pyrosetta.rosetta.protocols.constraint_movers.ConstraintSetMover()
     csm.add_constraints(True)
-    csm.constraint_file(constraint_file)
+    # AMW TODO: change this to constraint_set(constraint_set)
+    csm.constraint_set(csts)
 
     return csm
 

--- a/deepab/build_fv/utils.py
+++ b/deepab/build_fv/utils.py
@@ -1,7 +1,7 @@
 import torch
 import pyrosetta
 
-from deepab.constraints import get_filtered_constraint_file
+from deepab.constraints import get_filtered_constraint_defs
 
 
 def migrate_seq_numbering(source_pose: pyrosetta.Pose,
@@ -13,14 +13,15 @@ def migrate_seq_numbering(source_pose: pyrosetta.Pose,
 
 
 def get_constraint_set_mover(
-    csts: pyrosetta.rosetta.core.scoring.constraints.ConstraintSet#,
+    csts: pyrosetta.rosetta.core.scoring.constraints.ConstraintSet  #,
     #**kwargs
 ) -> pyrosetta.rosetta.protocols.constraint_movers.ConstraintSetMover:
-    
+
     if csts == None:
-        print("We're now operating under logic where this shouldn't be possible")
+        print(
+            "We're now operating under logic where this shouldn't be possible")
         quit()
-    #    constraint_file = get_filtered_constraint_file(**kwargs)
+    #    constraint_file = get_filtered_constraint_defs(**kwargs)
 
     csm = pyrosetta.rosetta.protocols.constraint_movers.ConstraintSetMover()
     csm.add_constraints(True)

--- a/deepab/constraints/__init__.py
+++ b/deepab/constraints/__init__.py
@@ -3,4 +3,4 @@ from .Constraint import Constraint
 from .Residue import Residue
 from .ResiduePair import ResiduePair
 from .rosetta_constraint_generators import constraint_type_generator_dict
-from .write_constraints import get_constraint_residue_pairs, get_filtered_constraint_file
+from .write_constraints import get_constraint_residue_pairs, get_filtered_constraint_defs

--- a/deepab/constraints/rosetta_constraint_generators.py
+++ b/deepab/constraints/rosetta_constraint_generators.py
@@ -8,10 +8,10 @@ from .Constraint import Constraint
 logit_to_energy = lambda _, y: -1 * y
 
 
-def write_histogram_file(constraint: Constraint,
-                         prob_to_energy=logit_to_energy) -> str:
+def get_histogram(constraint: Constraint,
+                  prob_to_energy=logit_to_energy) -> str:
     """
-    Writes geometric distribution to histogram file
+    Creates histogram string from geometric distribution
     """
 
     x_vals = [str(round(val.item(), 5)) for val in constraint.x_vals]
@@ -29,19 +29,20 @@ def write_histogram_file(constraint: Constraint,
 def get_ca_distance_constraint(constraint: Constraint,
                                prob_to_energy=logit_to_energy) -> str:
     """
-    Writes CA-CA distance distribution to histogram file and returns constraint line
+    Returns constraint line for CA-CA distance distribution
     """
     assert type(constraint) == Constraint
     assert constraint.constraint_type == ConstraintType.ca_distance
 
-    histogram_contents = write_histogram_file(constraint,
-                                          prob_to_energy=prob_to_energy)
+    histogram_contents = get_histogram(constraint,
+                                       prob_to_energy=prob_to_energy)
 
     residue_1 = constraint.residue_1
     residue_2 = constraint.residue_2
 
     constraint_line = "AtomPair CA {0} CA {1} SPLINE ca_dist_{0}_{1} NONE 0 1 {3} {2}\n".format(
-        residue_1.index, residue_2.index, histogram_contents, constraint.bin_width)
+        residue_1.index, residue_2.index, histogram_contents,
+        constraint.bin_width)
 
     return constraint_line
 
@@ -49,19 +50,20 @@ def get_ca_distance_constraint(constraint: Constraint,
 def get_cb_distance_constraint(constraint: Constraint,
                                prob_to_energy=logit_to_energy) -> str:
     """
-    Writes CB-CB distance distribution to histogram file and returns constraint line
+    Returns constraint line for CB-CB distance distribution
     """
     assert type(constraint) == Constraint
     assert constraint.constraint_type == ConstraintType.cb_distance
 
-    histogram_contents = write_histogram_file(constraint,
-                                          prob_to_energy=prob_to_energy)
+    histogram_contents = get_histogram(constraint,
+                                       prob_to_energy=prob_to_energy)
 
     residue_1 = constraint.residue_1
     residue_2 = constraint.residue_2
 
     constraint_line = "AtomPair CB {0} CB {1} SPLINE cb_dist_{0}_{1} NONE 0 1 {3} {2}\n".format(
-        residue_1.index, residue_2.index, histogram_contents, constraint.bin_width)
+        residue_1.index, residue_2.index, histogram_contents,
+        constraint.bin_width)
 
     return constraint_line
 
@@ -69,19 +71,20 @@ def get_cb_distance_constraint(constraint: Constraint,
 def get_no_distance_constraint(constraint: Constraint,
                                prob_to_energy=logit_to_energy) -> str:
     """
-    Writes N-O distance distribution to histogram file and returns constraint line
+    Returns constraint line for N-O distance distribution
     """
     assert type(constraint) == Constraint
     assert constraint.constraint_type == ConstraintType.no_distance
 
-    histogram_contents = write_histogram_file(constraint,
-                                          prob_to_energy=prob_to_energy)
+    histogram_contents = get_histogram(constraint,
+                                       prob_to_energy=prob_to_energy)
 
     residue_1 = constraint.residue_1
     residue_2 = constraint.residue_2
 
     constraint_line = "AtomPair N {0} O {1} SPLINE no_dist_{0}_{1} NONE 0 1 {3} {2}\n".format(
-        residue_1.index, residue_2.index, histogram_contents, constraint.bin_width)
+        residue_1.index, residue_2.index, histogram_contents,
+        constraint.bin_width)
 
     return constraint_line
 
@@ -89,7 +92,7 @@ def get_no_distance_constraint(constraint: Constraint,
 def get_omega_dihedral_constraint(constraint: Constraint,
                                   prob_to_energy=logit_to_energy) -> str:
     """
-    Writes omega dihedral distribution to histogram file and returns constraint line
+    Returns constraint line for omega dihedral distribution
     """
     assert type(constraint) == Constraint
     assert constraint.constraint_type == ConstraintType.omega_dihedral
@@ -97,14 +100,15 @@ def get_omega_dihedral_constraint(constraint: Constraint,
     assert constraint.residue_1.identity != "G"
     assert constraint.residue_2.identity != "G"
 
-    histogram_contents = write_histogram_file(constraint,
-                                          prob_to_energy=prob_to_energy)
+    histogram_contents = get_histogram(constraint,
+                                       prob_to_energy=prob_to_energy)
 
     residue_1 = constraint.residue_1
     residue_2 = constraint.residue_2
 
     constraint_line = "Dihedral CA {0} CB {0} CB {1} CA {1} SPLINE omega_{0}_{1} NONE 0 1 {3} {2}\n".format(
-        residue_1.index, residue_2.index, histogram_contents, constraint.bin_width)
+        residue_1.index, residue_2.index, histogram_contents,
+        constraint.bin_width)
 
     return constraint_line
 
@@ -112,7 +116,7 @@ def get_omega_dihedral_constraint(constraint: Constraint,
 def get_theta_dihedral_constraint(constraint: Constraint,
                                   prob_to_energy=logit_to_energy) -> str:
     """
-    Writes theta dihedral distribution to histogram file and returns constraint line
+    Returns constraint line for theta dihedral distribution
     """
     assert type(constraint) == Constraint
     assert constraint.constraint_type == ConstraintType.theta_dihedral
@@ -120,14 +124,15 @@ def get_theta_dihedral_constraint(constraint: Constraint,
     assert constraint.residue_1.identity != "G"
     assert constraint.residue_2.identity != "G"
 
-    histogram_contents = write_histogram_file(constraint,
-                                          prob_to_energy=prob_to_energy)
+    histogram_contents = get_histogram(constraint,
+                                       prob_to_energy=prob_to_energy)
 
     residue_1 = constraint.residue_1
     residue_2 = constraint.residue_2
 
     constraint_line = "Dihedral N {0} CA {0} CB {0} CB {1} SPLINE theta_{0}_{1} NONE 0 1 {3} {2}\n".format(
-        residue_1.index, residue_2.index, histogram_contents, constraint.bin_width)
+        residue_1.index, residue_2.index, histogram_contents,
+        constraint.bin_width)
 
     return constraint_line
 
@@ -135,7 +140,7 @@ def get_theta_dihedral_constraint(constraint: Constraint,
 def get_phi_planar_constraint(constraint: Constraint,
                               prob_to_energy=logit_to_energy) -> str:
     """
-    Writes phi planar distribution to histogram file and returns constraint line
+    Returns constraint line for phi planar distribution
     """
     assert type(constraint) == Constraint
     assert constraint.constraint_type == ConstraintType.phi_planar
@@ -143,14 +148,15 @@ def get_phi_planar_constraint(constraint: Constraint,
     assert constraint.residue_1.identity != "G"
     assert constraint.residue_2.identity != "G"
 
-    histogram_contents = write_histogram_file(constraint,
-                                          prob_to_energy=prob_to_energy)
+    histogram_contents = get_histogram(constraint,
+                                       prob_to_energy=prob_to_energy)
 
     residue_1 = constraint.residue_1
     residue_2 = constraint.residue_2
 
     constraint_line = "Angle CA {0} CB {0} CB {1} SPLINE phi_{0}_{1} NONE 0 1 {3} {2}\n".format(
-        residue_1.index, residue_2.index, histogram_contents, constraint.bin_width)
+        residue_1.index, residue_2.index, histogram_contents,
+        constraint.bin_width)
 
     return constraint_line
 

--- a/deepab/constraints/rosetta_constraint_generators.py
+++ b/deepab/constraints/rosetta_constraint_generators.py
@@ -9,7 +9,6 @@ logit_to_energy = lambda _, y: -1 * y
 
 
 def write_histogram_file(constraint: Constraint,
-                         histogram_dir: str,
                          prob_to_energy=logit_to_energy) -> str:
     """
     Writes geometric distribution to histogram file
@@ -21,23 +20,13 @@ def write_histogram_file(constraint: Constraint,
         for val in prob_to_energy(constraint.x_vals, constraint.y_vals)
     ]
 
-    x_axis = "x_axis\t" + "\t".join([val for val in x_vals])
-    y_axis = "y_axis\t" + "\t".join([val for val in y_vals])
+    x_axis = "x_axis " + " ".join([val for val in x_vals])
+    y_axis = "y_axis " + " ".join([val for val in y_vals])
 
-    histogram_file = "{}_{}_{}".format(constraint.constraint_type.name,
-                                       constraint.residue_1.index,
-                                       constraint.residue_2.index)
-    histogram_file = os.path.join(histogram_dir, histogram_file)
-
-    with open(histogram_file, "w") as f:
-        f.write(x_axis + "\n")
-        f.write(y_axis + "\n")
-
-    return histogram_file
+    return f"{x_axis} {y_axis}"
 
 
 def get_ca_distance_constraint(constraint: Constraint,
-                               histogram_dir: str,
                                prob_to_energy=logit_to_energy) -> str:
     """
     Writes CA-CA distance distribution to histogram file and returns constraint line
@@ -45,21 +34,19 @@ def get_ca_distance_constraint(constraint: Constraint,
     assert type(constraint) == Constraint
     assert constraint.constraint_type == ConstraintType.ca_distance
 
-    histogram_file = write_histogram_file(constraint,
-                                          histogram_dir,
+    histogram_contents = write_histogram_file(constraint,
                                           prob_to_energy=prob_to_energy)
 
     residue_1 = constraint.residue_1
     residue_2 = constraint.residue_2
 
-    constraint_line = "AtomPair CA {0} CA {1} SPLINE ca_dist_{0}_{1} {2} 0 1 {3}\n".format(
-        residue_1.index, residue_2.index, histogram_file, constraint.bin_width)
+    constraint_line = "AtomPair CA {0} CA {1} SPLINE ca_dist_{0}_{1} NONE 0 1 {3} {2}\n".format(
+        residue_1.index, residue_2.index, histogram_contents, constraint.bin_width)
 
     return constraint_line
 
 
 def get_cb_distance_constraint(constraint: Constraint,
-                               histogram_dir: str,
                                prob_to_energy=logit_to_energy) -> str:
     """
     Writes CB-CB distance distribution to histogram file and returns constraint line
@@ -67,21 +54,19 @@ def get_cb_distance_constraint(constraint: Constraint,
     assert type(constraint) == Constraint
     assert constraint.constraint_type == ConstraintType.cb_distance
 
-    histogram_file = write_histogram_file(constraint,
-                                          histogram_dir,
+    histogram_contents = write_histogram_file(constraint,
                                           prob_to_energy=prob_to_energy)
 
     residue_1 = constraint.residue_1
     residue_2 = constraint.residue_2
 
-    constraint_line = "AtomPair CB {0} CB {1} SPLINE cb_dist_{0}_{1} {2} 0 1 {3}\n".format(
-        residue_1.index, residue_2.index, histogram_file, constraint.bin_width)
+    constraint_line = "AtomPair CB {0} CB {1} SPLINE cb_dist_{0}_{1} NONE 0 1 {3} {2}\n".format(
+        residue_1.index, residue_2.index, histogram_contents, constraint.bin_width)
 
     return constraint_line
 
 
 def get_no_distance_constraint(constraint: Constraint,
-                               histogram_dir: str,
                                prob_to_energy=logit_to_energy) -> str:
     """
     Writes N-O distance distribution to histogram file and returns constraint line
@@ -89,21 +74,19 @@ def get_no_distance_constraint(constraint: Constraint,
     assert type(constraint) == Constraint
     assert constraint.constraint_type == ConstraintType.no_distance
 
-    histogram_file = write_histogram_file(constraint,
-                                          histogram_dir,
+    histogram_contents = write_histogram_file(constraint,
                                           prob_to_energy=prob_to_energy)
 
     residue_1 = constraint.residue_1
     residue_2 = constraint.residue_2
 
-    constraint_line = "AtomPair N {0} O {1} SPLINE no_dist_{0}_{1} {2} 0 1 {3}\n".format(
-        residue_1.index, residue_2.index, histogram_file, constraint.bin_width)
+    constraint_line = "AtomPair N {0} O {1} SPLINE no_dist_{0}_{1} NONE 0 1 {3} {2}\n".format(
+        residue_1.index, residue_2.index, histogram_contents, constraint.bin_width)
 
     return constraint_line
 
 
 def get_omega_dihedral_constraint(constraint: Constraint,
-                                  histogram_dir: str,
                                   prob_to_energy=logit_to_energy) -> str:
     """
     Writes omega dihedral distribution to histogram file and returns constraint line
@@ -114,21 +97,19 @@ def get_omega_dihedral_constraint(constraint: Constraint,
     assert constraint.residue_1.identity != "G"
     assert constraint.residue_2.identity != "G"
 
-    histogram_file = write_histogram_file(constraint,
-                                          histogram_dir,
+    histogram_contents = write_histogram_file(constraint,
                                           prob_to_energy=prob_to_energy)
 
     residue_1 = constraint.residue_1
     residue_2 = constraint.residue_2
 
-    constraint_line = "Dihedral CA {0} CB {0} CB {1} CA {1} SPLINE omega_{0}_{1} {2} 0 1 {3}\n".format(
-        residue_1.index, residue_2.index, histogram_file, constraint.bin_width)
+    constraint_line = "Dihedral CA {0} CB {0} CB {1} CA {1} SPLINE omega_{0}_{1} NONE 0 1 {3} {2}\n".format(
+        residue_1.index, residue_2.index, histogram_contents, constraint.bin_width)
 
     return constraint_line
 
 
 def get_theta_dihedral_constraint(constraint: Constraint,
-                                  histogram_dir: str,
                                   prob_to_energy=logit_to_energy) -> str:
     """
     Writes theta dihedral distribution to histogram file and returns constraint line
@@ -139,21 +120,19 @@ def get_theta_dihedral_constraint(constraint: Constraint,
     assert constraint.residue_1.identity != "G"
     assert constraint.residue_2.identity != "G"
 
-    histogram_file = write_histogram_file(constraint,
-                                          histogram_dir,
+    histogram_contents = write_histogram_file(constraint,
                                           prob_to_energy=prob_to_energy)
 
     residue_1 = constraint.residue_1
     residue_2 = constraint.residue_2
 
-    constraint_line = "Dihedral N {0} CA {0} CB {0} CB {1} SPLINE theta_{0}_{1} {2} 0 1 {3}\n".format(
-        residue_1.index, residue_2.index, histogram_file, constraint.bin_width)
+    constraint_line = "Dihedral N {0} CA {0} CB {0} CB {1} SPLINE theta_{0}_{1} NONE 0 1 {3} {2}\n".format(
+        residue_1.index, residue_2.index, histogram_contents, constraint.bin_width)
 
     return constraint_line
 
 
 def get_phi_planar_constraint(constraint: Constraint,
-                              histogram_dir: str,
                               prob_to_energy=logit_to_energy) -> str:
     """
     Writes phi planar distribution to histogram file and returns constraint line
@@ -164,15 +143,14 @@ def get_phi_planar_constraint(constraint: Constraint,
     assert constraint.residue_1.identity != "G"
     assert constraint.residue_2.identity != "G"
 
-    histogram_file = write_histogram_file(constraint,
-                                          histogram_dir,
+    histogram_contents = write_histogram_file(constraint,
                                           prob_to_energy=prob_to_energy)
 
     residue_1 = constraint.residue_1
     residue_2 = constraint.residue_2
 
-    constraint_line = "Angle CA {0} CB {0} CB {1} SPLINE phi_{0}_{1} {2} 0 1 {3}\n".format(
-        residue_1.index, residue_2.index, histogram_file, constraint.bin_width)
+    constraint_line = "Angle CA {0} CB {0} CB {1} SPLINE phi_{0}_{1} NONE 0 1 {3} {2}\n".format(
+        residue_1.index, residue_2.index, histogram_contents, constraint.bin_width)
 
     return constraint_line
 

--- a/deepab/constraints/write_constraints.py
+++ b/deepab/constraints/write_constraints.py
@@ -131,7 +131,7 @@ def get_constraint_residue_pairs(model: torch.nn.Module,
     return residue_pairs
 
 
-def get_filtered_constraint_file(residue_pairs: List[ResiduePair],
+def get_filtered_constraint_defs(residue_pairs: List[ResiduePair],
                                  threshold: float = 0.1,
                                  res_range: Iterable = None,
                                  max_separation: int = math.inf,
@@ -143,8 +143,9 @@ def get_filtered_constraint_file(residue_pairs: List[ResiduePair],
                                  constraint_types: List[ConstraintType] = None,
                                  constraint_filters: List = None,
                                  prob_to_energy=logit_to_energy):
-    # if not os.path.exists(constraint_dir):
-    #     os.mkdir(constraint_dir)
+    """
+    returns an in-memory list of text constraint definitions
+    """
 
     # Use default constraint filters if none are provided
     if constraint_filters is None:
@@ -199,14 +200,7 @@ def get_filtered_constraint_file(residue_pairs: List[ResiduePair],
 
     constraints = [c for c in constraints if c.modal_y >= threshold]
 
-    # constraint_file = os.path.join(constraint_dir, "constraints.cst")
-    # with open(constraint_file, "w") as f:
-    #     for c in constraints:
-    #         f.write(constraint_type_generator_dict[c.constraint_type](
-    #             c, prob_to_energy=prob_to_energy))
-    
-    # now this set of functions returns an in-memory list of 
-    # text constraint defs. ordinarily i'd have it return Constraints
-    # but those are hard to create without a Pose
-    return [constraint_type_generator_dict[c.constraint_type](
-                 c, prob_to_energy=prob_to_energy) for c in constraints]
+    return [
+        constraint_type_generator_dict[c.constraint_type](
+            c, prob_to_energy=prob_to_energy) for c in constraints
+    ]

--- a/deepab/constraints/write_constraints.py
+++ b/deepab/constraints/write_constraints.py
@@ -147,10 +147,6 @@ def get_filtered_constraint_file(residue_pairs: List[ResiduePair],
     if not os.path.exists(constraint_dir):
         os.mkdir(constraint_dir)
 
-    histogram_dir = os.path.join(constraint_dir, "histograms")
-    if not os.path.exists(histogram_dir):
-        os.mkdir(histogram_dir)
-
     # Use default constraint filters if none are provided
     if constraint_filters is None:
         constraint_filters = [
@@ -208,6 +204,6 @@ def get_filtered_constraint_file(residue_pairs: List[ResiduePair],
     with open(constraint_file, "w") as f:
         for c in constraints:
             f.write(constraint_type_generator_dict[c.constraint_type](
-                c, histogram_dir, prob_to_energy=prob_to_energy))
+                c, prob_to_energy=prob_to_energy))
 
     return constraint_file

--- a/deepab/constraints/write_constraints.py
+++ b/deepab/constraints/write_constraints.py
@@ -132,7 +132,6 @@ def get_constraint_residue_pairs(model: torch.nn.Module,
 
 
 def get_filtered_constraint_file(residue_pairs: List[ResiduePair],
-                                 constraint_dir: str,
                                  threshold: float = 0.1,
                                  res_range: Iterable = None,
                                  max_separation: int = math.inf,
@@ -144,8 +143,8 @@ def get_filtered_constraint_file(residue_pairs: List[ResiduePair],
                                  constraint_types: List[ConstraintType] = None,
                                  constraint_filters: List = None,
                                  prob_to_energy=logit_to_energy):
-    if not os.path.exists(constraint_dir):
-        os.mkdir(constraint_dir)
+    # if not os.path.exists(constraint_dir):
+    #     os.mkdir(constraint_dir)
 
     # Use default constraint filters if none are provided
     if constraint_filters is None:
@@ -200,10 +199,14 @@ def get_filtered_constraint_file(residue_pairs: List[ResiduePair],
 
     constraints = [c for c in constraints if c.modal_y >= threshold]
 
-    constraint_file = os.path.join(constraint_dir, "constraints.cst")
-    with open(constraint_file, "w") as f:
-        for c in constraints:
-            f.write(constraint_type_generator_dict[c.constraint_type](
-                c, prob_to_energy=prob_to_energy))
-
-    return constraint_file
+    # constraint_file = os.path.join(constraint_dir, "constraints.cst")
+    # with open(constraint_file, "w") as f:
+    #     for c in constraints:
+    #         f.write(constraint_type_generator_dict[c.constraint_type](
+    #             c, prob_to_energy=prob_to_energy))
+    
+    # now this set of functions returns an in-memory list of 
+    # text constraint defs. ordinarily i'd have it return Constraints
+    # but those are hard to create without a Pose
+    return [constraint_type_generator_dict[c.constraint_type](
+                 c, prob_to_energy=prob_to_energy) for c in constraints]

--- a/predict.py
+++ b/predict.py
@@ -10,7 +10,7 @@ import pyrosetta
 import deepab
 from deepab.models.AbResNet import load_model
 from deepab.models.ModelEnsemble import ModelEnsemble
-from deepab.build_fv.build_cen_fa import build_initial_fv, get_cst_file, refine_fv
+from deepab.build_fv.build_cen_fa import build_initial_fv, get_cst_defs, refine_fv
 from deepab.metrics.rosetta_ab import get_ab_metrics
 from deepab.util.pdb import renumber_pdb
 
@@ -22,13 +22,13 @@ def prog_print(text):
 
 
 def refine_fv_(args):
-    in_pdb_file, out_pdb_file, cst_file = args
-    return refine_fv(in_pdb_file, out_pdb_file, cst_file)
+    in_pdb_file, out_pdb_file, cst_defs = args
+    return refine_fv(in_pdb_file, out_pdb_file, cst_defs)
 
 
 def build_structure(model,
                     fasta_file,
-                    cst_file,
+                    cst_defs,
                     out_dir,
                     target="pred",
                     num_decoys=5,
@@ -49,7 +49,7 @@ def build_structure(model,
     prog_print("Creating decoys structures")
     decoy_pdb_pattern = os.path.join(decoy_dir,
                                      "{}.deepab.{{}}.pdb".format(target))
-    refine_args = [(mds_pdb_file, decoy_pdb_pattern.format(i), cst_file)
+    refine_args = [(mds_pdb_file, decoy_pdb_pattern.format(i), cst_defs)
                    for i in range(num_decoys)]
     decoy_scores = process_map(refine_fv_, refine_args, max_workers=num_procs)
 
@@ -173,14 +173,12 @@ def _cli():
     # cst_file = os.path.join(constraint_dir, "hb_csm", "constraints.cst")
     # if not os.path.exists(cst_file):
     prog_print("Generating constraints")
-    cst_file = get_cst_file(model,
-                            fasta_file,
-                            device=device)
+    cst_defs = get_cst_defs(model, fasta_file, device=device)
 
     if decoys > 0:
         pred_pdb = build_structure(model,
                                    fasta_file,
-                                   cst_file,
+                                   cst_defs,
                                    pred_dir,
                                    target=target,
                                    num_decoys=decoys,

--- a/predict.py
+++ b/predict.py
@@ -22,13 +22,13 @@ def prog_print(text):
 
 
 def refine_fv_(args):
-    in_pdb_file, out_pdb_file, cst_file = args
-    return refine_fv(in_pdb_file, out_pdb_file, cst_file)
+    in_pdb_file, out_pdb_file, cst_files = args
+    return refine_fv(in_pdb_file, out_pdb_file, cst_files)
 
 
 def build_structure(model,
                     fasta_file,
-                    cst_file,
+                    cst_files,
                     out_dir,
                     target="pred",
                     num_decoys=5,
@@ -49,7 +49,7 @@ def build_structure(model,
     prog_print("Creating decoys structures")
     decoy_pdb_pattern = os.path.join(decoy_dir,
                                      "{}.deepab.{{}}.pdb".format(target))
-    refine_args = [(mds_pdb_file, decoy_pdb_pattern.format(i), cst_file)
+    refine_args = [(mds_pdb_file, decoy_pdb_pattern.format(i), cst_files)
                    for i in range(num_decoys)]
     decoy_scores = process_map(refine_fv_, refine_args, max_workers=num_procs)
 
@@ -168,15 +168,14 @@ def _cli():
     init_string = "-mute all -check_cdr_chainbreaks false -detect_disulf true"
     pyrosetta.init(init_string)
 
-    constraint_dir = os.path.join(pred_dir, "constraints")
-    os.makedirs(constraint_dir, exist_ok=True)
-    cst_file = os.path.join(constraint_dir, "hb_csm", "constraints.cst")
-    if not os.path.exists(cst_file):
-        prog_print("Generating constraints")
-        cst_file = get_cst_file(model,
-                                fasta_file,
-                                constraint_dir,
-                                device=device)
+    # constraint_dir = os.path.join(pred_dir, "constraints")
+    # os.makedirs(constraint_dir, exist_ok=True)
+    # cst_file = os.path.join(constraint_dir, "hb_csm", "constraints.cst")
+    # if not os.path.exists(cst_file):
+    prog_print("Generating constraints")
+    cst_file = get_cst_file(model,
+                            fasta_file,
+                            device=device)
 
     if decoys > 0:
         pred_pdb = build_structure(model,
@@ -192,8 +191,8 @@ def _cli():
         if renumber:
             renumber_pdb(pred_pdb, pred_pdb)
 
-    if not keep_constraints:
-        os.system("rm -rf {}".format(constraint_dir))
+    # if not keep_constraints:
+    #     os.system("rm -rf {}".format(constraint_dir))
 
     if native_pdb is not None and os.path.exists(native_pdb):
         pose = pyrosetta.pose_from_pdb(pred_pdb)

--- a/predict.py
+++ b/predict.py
@@ -22,13 +22,13 @@ def prog_print(text):
 
 
 def refine_fv_(args):
-    in_pdb_file, out_pdb_file, cst_files = args
-    return refine_fv(in_pdb_file, out_pdb_file, cst_files)
+    in_pdb_file, out_pdb_file, cst_file = args
+    return refine_fv(in_pdb_file, out_pdb_file, cst_file)
 
 
 def build_structure(model,
                     fasta_file,
-                    cst_files,
+                    cst_file,
                     out_dir,
                     target="pred",
                     num_decoys=5,
@@ -49,7 +49,7 @@ def build_structure(model,
     prog_print("Creating decoys structures")
     decoy_pdb_pattern = os.path.join(decoy_dir,
                                      "{}.deepab.{{}}.pdb".format(target))
-    refine_args = [(mds_pdb_file, decoy_pdb_pattern.format(i), cst_files)
+    refine_args = [(mds_pdb_file, decoy_pdb_pattern.format(i), cst_file)
                    for i in range(num_decoys)]
     decoy_scores = process_map(refine_fv_, refine_args, max_workers=num_procs)
 


### PR DESCRIPTION
Because of Vikram's work back in May 2021 on `SPLINE` function definitions, we no longer need to load in an external histogram.

Because functions in `ConstraintIO` take `std::istream`, we can feed it a PyRosetta-initialized `std::stringstream` from `'\n'.join(bunch_of_constraint_definitions)`.

There is almost certainly a more elegant solution with potentially more than marginal performance benefits: instead of writing a bunch of strings, then passing through string parsing (ordinarily a rounding error versus relax, but maybe not when there are ~50k constraints equivalent to 200MB of strings) we could simply accumulate `[(cst_type, (args)]` and pass these args to the appropriate constraint generator function, or something.

That said, this seems like a premature optimization until we've at least re-benchmarked this version.